### PR TITLE
Install only needed system requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM php:7.1-cli
-
-RUN \
-	apt-get update && \
-	# for intl
-	apt-get install -y libicu-dev && \
-	docker-php-ext-install -j$(nproc) intl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   app:
-    build: .
+    image: php:7.1-cli
     volumes:
       - ./:/usr/src/app
     working_dir: /usr/src/app


### PR DESCRIPTION
Remove custom Dockerfile used to install unneeded extension. Use official php image.
Cuts build time by about a minute.