### PR TITLE
Improve exceptions in test fixture

### DIFF
--- a/tests/Unit/FrozenValueObject.php
+++ b/tests/Unit/FrozenValueObject.php
@@ -19,7 +19,7 @@ class FrozenValueObject {
 
 	public function getMainContent(): string {
 		if ( $this->mainContent === null ) {
-			throw new \RuntimeException( "Field mainContent cannot be null" );
+			throw new \LogicException( "You must set a value before calling " . __METHOD__ );
 		}
 		return $this->mainContent;
 	}
@@ -31,7 +31,7 @@ class FrozenValueObject {
 
 	public function getHeaderContent(): string {
 		if ( $this->headerContent === null ) {
-			throw new \RuntimeException( "Field headerContent cannot be null" );
+			throw new \LogicException( "You must set a value before calling " . __METHOD__ );
 		}
 		return $this->headerContent;
 	}
@@ -43,7 +43,7 @@ class FrozenValueObject {
 
 	public function getFooterContent(): string {
 		if ( $this->footerContent === null ) {
-			throw new \RuntimeException( "Field footerContent cannot be null" );
+			throw new \LogicException( "You must set a value before calling " . __METHOD__ );
 		}
 		return $this->footerContent;
 	}


### PR DESCRIPTION
Replace RuntimeException with LogicException, because if you call a
getter before setting a value, you're not using the class right. This is
a developer mistake, not a runtime anomaly.

See https://moxio.com/blog/best-practices-for-php-exception-handling/

This change and the original introduction of the null checks show the
futility of FreezableValueObject in modern PHP, where we're better off
with value objects that have readonly, non-nullable constructor
parameters. Right now, FreezableValueObject also tries to implement the
builder pattern by allowing for null values, but at the cost of having
to add null checks to every getter, which defies the purpose of
`assertNotNullFields`
